### PR TITLE
Added deobf Jar to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,3 +61,12 @@ processResources
         exclude 'mcmod.info'
     }
 }
+
+task deobfJar(type: Jar) {
+    from sourceSets.main.output
+    classifier = "deobf"
+}
+
+artifacts {
+    archives deobfJar
+}


### PR DESCRIPTION
Saw your post on the FTB forums that said you didn't know how to make deobfuscated jars...welp, here ya go. Just run gradle(w) build like normal and it will produce both a normal and deobfuscated mod.
